### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main  # replace with your default branch if not 'main'
 
+permissions:
+  contents: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cristiadu/cristiadu.github.io/security/code-scanning/1](https://github.com/cristiadu/cristiadu.github.io/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's steps:
- The `Checkout` step requires `contents: read` to access the repository's files.
- The `Deploy` step requires `contents: write` to push changes to the `live` branch.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the `build-and-deploy` job for more granular control. In this case, adding it at the root level is sufficient and ensures clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
