### PR TITLE
fix: cache bust production bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,8 +27,9 @@ export default (env, argv) => {
       })
     ],
     output: {
-      filename: 'bundle.js',
-      path: path.resolve(__dirname, 'dist')
+      filename: 'bundle.[contenthash].js',
+      path: path.resolve(__dirname, 'dist'),
+      clean: true
     },
     module: {
       rules: [


### PR DESCRIPTION
Description

Adds a content hash to the generated production bundle filename and cleans dist before each build. This prevents browsers or GitHub Pages edge caches from reusing an old bundle.js after dependency/runtime changes while index.html has been redeployed.

Validation

- [x] ./node_modules/.bin/webpack --mode production
- [x] ./node_modules/.bin/eslint .
- [x] ./node_modules/.bin/vitest run
- [x] rg "jsxDEV|jsx-dev-runtime" dist returns no matches
- [x] dist/index.html references bundle.<contenthash>.js